### PR TITLE
Add setup wizard step which prompts the user for the demodulator

### DIFF
--- a/librarian_sdr/config.ini
+++ b/librarian_sdr/config.ini
@@ -1,0 +1,8 @@
+[exports]
+wizard = setup.SDRStep
+
+
+[sdr]
+
+# Location of sdr binary
+binary_path = /usr/sbin/sdr100

--- a/librarian_sdr/forms.py
+++ b/librarian_sdr/forms.py
@@ -1,0 +1,15 @@
+from bottle_utils import form
+from bottle_utils.i18n import lazy_gettext as _
+
+
+class SDRForm(form.Form):
+    sdr_binary = form.FileField(
+        _("SDR Executable"),
+        validators=[
+            form.Required(messages={
+                # Translators, shown as a prompt to user during setup wizard
+                # step.
+                'required': _('Please select the SDR executable')
+            })
+        ]
+    )

--- a/librarian_sdr/helpers.py
+++ b/librarian_sdr/helpers.py
@@ -1,0 +1,58 @@
+import os
+import stat
+import logging
+import subprocess
+
+from librarian.core.exts import ext_container as exts
+
+
+ONDD_SERVICE = 'ondd'
+SDR_SERVICE = 'sdr100'
+
+
+def save_sdr(sdr, path):
+    """
+    Saves a file-like obj `sdr` at location `path` and sets file permissions.
+    """
+    if os.path.exists(path):
+        logging.info('Replacing existing sdr binary')
+    logging.debug('Saving sdr binary at path {}'.format(path))
+    try:
+        copy_file(sdr, path)
+        # Set the executable to be world executable
+        # 755 => rwxr-xr-x
+        mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+        os.chmod(path, mode)
+    except:
+        logging.exception('Exception while saving SDR binary at {}'.format(
+            path))
+        raise
+
+
+def restart_tuners():
+    """ Restarts SDR & ONDD by restarting the processes."""
+    exts.tasks.schedule(_restart_tuners)
+
+
+def copy_file(src, dest_path, buff_size=2 ** 16):
+    with open(dest_path, 'wb') as dest:
+        while True:
+            buff = src.read(buff_size)
+            if not buff:
+                break
+            dest.write(buff)
+
+
+def _restart_tuners():
+    restart_service(ONDD_SERVICE)
+    restart_service(SDR_SERVICE)
+
+
+def restart_service(name):
+    logging.debug("Restarting service: '{}'".format(name))
+    try:
+        exit_code = subprocess.call(['service', name, 'restart'])
+    except:
+        logging.exception('Exception while restarting service {}'.format(name))
+        return 1
+    return exit_code

--- a/librarian_sdr/setup.py
+++ b/librarian_sdr/setup.py
@@ -1,0 +1,50 @@
+import os
+import logging
+
+from bottle import request
+from bottle_utils.i18n import lazy_gettext as _
+from librarian.core.exts import ext_container as exts
+
+from .forms import SDRForm
+from .helpers import save_sdr, restart_tuners
+
+
+def context(successful=False, form=None, message=None):
+    form = form or SDRForm()
+    return dict(successful=successful, form=form,
+                message=message, step_multipart=True)
+
+
+class SDRStep(object):
+    name = 'sdr'
+    index = 25
+    template = 'setup/step_sdr.tpl'
+
+    @staticmethod
+    def test():
+        path = exts.config['sdr.binary_path']
+        return not os.path.exists(path)
+
+    @staticmethod
+    def get():
+        return dict(form=SDRForm(), step_multipart=True)
+
+    @staticmethod
+    def post():
+        form = SDRForm(request.files)
+        valid = form.is_valid()
+        if valid:
+            uploaded_binary = form.processed_data['sdr_binary']
+            try:
+                path = exts.config['sdr.binary_path']
+                save_sdr(uploaded_binary.file, path)
+                restart_tuners()
+                return dict(successful=True)
+            except:
+                logging.exception('Exception during SDR installation')
+                # Translators, shown when installation of SDR executable failed
+                # during setup wizard step.
+                return context(message=_('Demodulator Installation failed'))
+        else:
+            # Translators, shown as a prompt to user during setup wizard step.
+            return context(message=_('Please select the demodulator executable'))

--- a/librarian_sdr/views/setup/step_sdr.tpl
+++ b/librarian_sdr/views/setup/step_sdr.tpl
@@ -1,0 +1,30 @@
+<%inherit file='/setup/setup_base.tpl'/>
+
+<%namespace name="forms" file="/ui/forms.tpl"/>
+
+<%block name="step_title">
+    <span class"icon icon-radio"></span>
+    ## Translators, used as step title during setup wizard, in demodulator 
+    ## installation step
+    ${_('Demodulator Installation')}
+</%block>
+
+<%block name="step_desc">
+    ## Translators, used as a prompt to the user during setup wizard, in 
+    ## demodulator installation step
+    <p>${_('Please select the demodulator executable.')}</p>
+</%block>
+
+<%block name="step">
+## Translators, used during demodulator installation step in setup wizard, to 
+## inform the user why they have to supply the executable
+<p class="o-field-help-message"> ${_('The software demodulator must be installed separately. Please upload the demodulator executable.')} </p>
+
+<div id="sdr-form">
+    ${forms.form_message(message)}
+    ${forms.field(form.sdr_binary)}
+    <button type="submit">
+        ${_('Upload')}
+    </button>
+</div>
+</%block>


### PR DESCRIPTION
This PR introduces the SDR installation step, in the setup wizard, which prompts the user to upload the demodulator. On successful upload, sdr and ondd are restarted.
This installation step is added prior to ONDD wizard step.
