### PR TITLE
Restart ondd only if not already running

### DIFF
--- a/librarian_sdr/config.ini
+++ b/librarian_sdr/config.ini
@@ -6,3 +6,7 @@ wizard = setup.SDRStep
 
 # Location of sdr binary
 binary_path = /usr/sbin/sdr100
+
+ondd_restart_command = service ondd restart
+
+sdr_restart_command = service sdr100 restart

--- a/librarian_sdr/setup.py
+++ b/librarian_sdr/setup.py
@@ -6,7 +6,7 @@ from bottle_utils.i18n import lazy_gettext as _
 from librarian.core.exts import ext_container as exts
 
 from .forms import SDRForm
-from .helpers import save_sdr, restart_tuners
+from .helpers import save_sdr, bootup_sdr
 
 
 def context(successful=False, form=None, message=None):
@@ -38,7 +38,7 @@ class SDRStep(object):
             try:
                 path = exts.config['sdr.binary_path']
                 save_sdr(uploaded_binary.file, path)
-                restart_tuners()
+                bootup_sdr()
                 return dict(successful=True)
             except:
                 logging.exception('Exception during SDR installation')


### PR DESCRIPTION
The command used to restart sdr100 & ondd processes can be specified via
the config keys `sdr.sdr_restart_command` and `sdr.ondd_restart_command`
